### PR TITLE
进一步简化 Golang 插件系统中 cmd 的 API

### DIFF
--- a/go/cmd/images.go
+++ b/go/cmd/images.go
@@ -102,9 +102,23 @@ func (idx *Index) MapImageCommand(
 	return c
 }
 
+// AddImageCommand invokes MapImageCommand with no return.
+func (idx *Index) AddImageCommand(
+	c *Command, f ImageHandler,
+) {
+	_ = idx.MapImageCommand(c, f)
+}
+
 // MapImageCommand issues defaultIndex.MapImageCommand.
 func MapImageCommand(
 	c *Command, f ImageHandler,
 ) *Command {
 	return defaultIndex.MapImageCommand(c, f)
+}
+
+// AddImageCommand issues defaultIndex.AddImageCommand.
+func AddImageCommand(
+	c *Command, f ImageHandler,
+) {
+	defaultIndex.AddImageCommand(c, f)
 }

--- a/go/cmd/mode.go
+++ b/go/cmd/mode.go
@@ -91,9 +91,23 @@ func (idx *Index) MapModeCommand(
 	return c
 }
 
+// AddModeCommand invokes MapModeCommand with no return.
+func (idx *Index) AddModeCommand(
+	c *Command, typ string, obj interface{}, f ModeHandler,
+) {
+	_ = idx.MapModeCommand(c, typ, obj, f)
+}
+
 // MapModeCommand issues defaultIndex.MapModeCommand.
 func MapModeCommand(
 	c *Command, typ string, obj interface{}, f ModeHandler,
 ) *Command {
 	return defaultIndex.MapModeCommand(c, typ, obj, f)
+}
+
+// MapModeCommand issues defaultIndex.AddModeCommand.
+func AddModeCommand(
+	c *Command, typ string, obj interface{}, f ModeHandler,
+) {
+	defaultIndex.AddModeCommand(c, typ, obj, f)
 }

--- a/go/cmd/runtimes.go
+++ b/go/cmd/runtimes.go
@@ -49,9 +49,23 @@ func (idx *Index) MapRuntimeCommand(
 	})
 }
 
+// AddRuntimeCommand issues MapRuntimeCommand with no return.
+func (idx *Index) AddRuntimeCommand(
+	c *Command, f RuntimeHandler,
+) {
+	_ = idx.MapRuntimeCommand(c, f)
+}
+
 // MapRuntimeCommand issues defaultIndex.MapRuntimeCommand.
 func MapRuntimeCommand(
 	c *Command, f RuntimeHandler,
 ) *Command {
 	return defaultIndex.MapRuntimeCommand(c, f)
+}
+
+// AddRuntimeCommand issues defaultIndex.AddRuntimeCommand.
+func AddRuntimeCommand(
+	c *Command, f RuntimeHandler,
+) {
+	defaultIndex.AddRuntimeCommand(c, f)
 }


### PR DESCRIPTION
1. 在 Golang 插件系统的 cmd API 中添加默认入口 `Execute*`。
2. 在 Golang 插件系统的 cmd API 中添加 `Add*` 类函数。