### PR TITLE
同步绑定接口以支持问脉 SDK v1.1

### DIFF
--- a/go/containerd/containerd.go
+++ b/go/containerd/containerd.go
@@ -7,6 +7,63 @@ import (
 	"github.com/chaitin/libveinmind/go/pkg/binding"
 )
 
+// newArgs is the internal state that a containerd.NewOption can
+// manipulate for creating a new containerd handle.
+type newArgs struct {
+	h binding.Handle
+}
+
+// NewOption is the option that can be used for initializing an
+// containerd.Containerd object.
+type NewOption func(*newArgs)
+
+// WithConfigPath specifies the path of containerd's config file.
+//
+// Specifying this argument is semantically equivalent to specifying
+// flag "--config" or "-c" to containerd, and its default search
+// path is "/etc/containerd/config.toml".
+//
+// Both containerd and veinmind will render
+// "/etc/containerd/config.toml" file as dispensible and fallback
+// to use internal default config if unspecified. But once the
+// argument is specified, it is no longer dispensible and error
+// will be raised if the config is not found.
+func WithConfigPath(path string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.ContainerdWithConfigPath(path)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
+// WithRootDir specifies the path of containerd's root directory.
+//
+// Specifying this argument is semantically equivalent to specifying
+// flag "--root" to containerd, and its default value is
+// "/var/lib/containerd".
+func WithRootDir(path string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.ContainerdWithRootDir(path)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
+// WithUniqueDesc specifies the unique descriptor of dockerd.
+//
+// This argument must be result of
+// containerd.(*Containerd).UniqueDesc() from another
+// containerd.Containerd instance, potentially from another
+// process. And the initialization might still fail if the API
+// runtime context has not been set up properly.
+func WithUniqueDesc(desc string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.ContainerdWithUniqueDesc(desc)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
 // Containerd is the connection established with a
 // containerd runtime.
 type Containerd struct {
@@ -16,11 +73,15 @@ type Containerd struct {
 	runtime binding.Handle
 }
 
-// New a containerd runtime by parsing the configurations
-// specified in "/var/lib/containerd" directory, assuming it is
-// defaultly installed.
-func New() (api.Runtime, error) {
-	h, err := binding.ContainerdNew()
+// New a containerd runtime object.
+func New(opts ...NewOption) (api.Runtime, error) {
+	hopt := binding.ContainerdMakeNewOptionList()
+	defer hopt.Free()
+	args := &newArgs{h: hopt}
+	for _, opt := range opts {
+		opt(args)
+	}
+	h, err := binding.ContainerdNew(hopt)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +90,13 @@ func New() (api.Runtime, error) {
 	result.Runtime = behaviour.NewRuntime(&result.runtime)
 	result.FileSystem = behaviour.NewFileSystem(&result.runtime)
 	return result, nil
+}
+
+// UniqueDesc represents the containerd runtime's initialization
+// arguments, which can be passed across process boundaries and
+// initialize the same docker in another process.
+func (d *Containerd) UniqueDesc() string {
+	return d.runtime.ContainerdUniqueDesc()
 }
 
 // Image represents a containerd image, which is guaranteed to

--- a/go/docker/docker.go
+++ b/go/docker/docker.go
@@ -7,6 +7,62 @@ import (
 	"github.com/chaitin/libveinmind/go/pkg/binding"
 )
 
+// newArgs is the internal state that a docker.NewOption can
+// manipulate for creating a new docker handle.
+type newArgs struct {
+	h binding.Handle
+}
+
+// NewOption is the option that can be used for initializing an
+// docker.Docker object.
+type NewOption func(*newArgs)
+
+// WithConfigPath specifies the path of dockerd's config file.
+//
+// Specifying this argument is semantically equivalent to specifying
+// flag "--config-file" to dockerd, and its default search path is
+// "/etc/docker/daemon.json".
+//
+// Both dockerd and veinmind will render "/etc/docker/daemon.json"
+// file as dispensible and fallback to use internal default config
+// if unspecified. But once the argument is specified, it is no
+// longer dispensible and error will be raised if the config is
+// not found.
+func WithConfigPath(path string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.DockerWithConfigPath(path)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
+// WithDataRootDir specifies the path of dockerd's data directory.
+//
+// Specifying this argument is semantically equivalent to specifying
+// flag "--data-root" to dockerd, and is default value is
+// "/var/lib/docker".
+func WithDataRootDir(path string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.DockerWithDataRootDir(path)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
+// WithUniqueDesc specifies the unique descriptor of dockerd.
+//
+// This argument must be result of docker.(*Docker).UniqueDesc()
+// from another docker.Docker instance, potentially from another
+// process. And the initialization might still fail if the API
+// runtime context has not been set up properly.
+func WithUniqueDesc(desc string) NewOption {
+	return func(opts *newArgs) {
+		opt := binding.DockerWithUniqueDesc(desc)
+		defer opt.Free()
+		opts.h.Append(opt)
+	}
+}
+
 // Docker is the connection established with a docker runtime.
 type Docker struct {
 	behaviour.Closer
@@ -15,10 +71,15 @@ type Docker struct {
 	runtime binding.Handle
 }
 
-// New a docker runtime by parsing the configurations specified
-// in "/etc/docker" directory, assuming it is defaultly installed.
-func New() (api.Runtime, error) {
-	h, err := binding.DockerNew()
+// New a docker runtime object.
+func New(opts ...NewOption) (api.Runtime, error) {
+	hopt := binding.DockerMakeNewOptionList()
+	defer hopt.Free()
+	args := &newArgs{h: hopt}
+	for _, opt := range opts {
+		opt(args)
+	}
+	h, err := binding.DockerNew(hopt)
 	if err != nil {
 		return nil, err
 	}
@@ -27,6 +88,13 @@ func New() (api.Runtime, error) {
 	result.Runtime = behaviour.NewRuntime(&result.runtime)
 	result.FileSystem = behaviour.NewFileSystem(&result.runtime)
 	return result, nil
+}
+
+// UniqueDesc represents the docker runtime's initialization
+// arguments, which can be passed across process boundaries and
+// initialize the same docker in another process.
+func (d *Docker) UniqueDesc() string {
+	return d.runtime.DockerUniqueDesc()
 }
 
 // Image represents a docker image, which is guaranteed to be

--- a/go/filesystem.go
+++ b/go/filesystem.go
@@ -12,6 +12,7 @@ type File interface {
 	io.ReadWriteCloser
 	io.ReaderAt
 	io.WriterAt
+	io.Seeker
 
 	Stat() (os.FileInfo, error)
 }

--- a/go/pkg/behaviour/filesystem.go
+++ b/go/pkg/behaviour/filesystem.go
@@ -73,6 +73,7 @@ type file struct {
 	ReaderAt
 	Writer
 	WriterAt
+	Seeker
 	file binding.Handle
 }
 
@@ -96,6 +97,7 @@ func NewFile(h binding.Handle) api.File {
 	f.ReaderAt = NewReaderAt(&f.file)
 	f.Writer = NewWriter(&f.file)
 	f.WriterAt = NewWriterAt(&f.file)
+	f.Seeker = NewSeeker(&f.file)
 	return f
 }
 

--- a/go/pkg/behaviour/io.go
+++ b/go/pkg/behaviour/io.go
@@ -88,3 +88,16 @@ func (w *WriterAt) WriteAt(b []byte, off int64) (int, error) {
 func NewWriterAt(h *binding.Handle) WriterAt {
 	return WriterAt{h: h}
 }
+
+// Seeker annotates handle to have io.Seeker behaviour.
+type Seeker struct {
+	h *binding.Handle
+}
+
+func (s *Seeker) Seek(off int64, whence int) (int64, error) {
+	return s.h.Seek(off, whence)
+}
+
+func NewSeeker(h *binding.Handle) Seeker {
+	return Seeker{h: h}
+}

--- a/go/pkg/binding/functions.go
+++ b/go/pkg/binding/functions.go
@@ -7,6 +7,10 @@ func (h Handle) Close() error {
 	return handleError(C.veinmind_Close(h.ID()))
 }
 
+func (h Handle) Append(item Handle) {
+	assertNoError(C.veinmind_Append(h.ID(), item.ID()))
+}
+
 func (h Handle) ErrorString() string {
 	var str Handle
 	assertNoError(C.veinmind_ErrorString(str.Ptr(), h.ID()))
@@ -107,6 +111,13 @@ func (h Handle) Open(path string) (Handle, error) {
 		return 0, err
 	}
 	return result, nil
+}
+
+func (h Handle) Seek(offset int64, whence int) (int64, error) {
+	var off C.int64_t
+	err := handleError(C.veinmind_Seek(&off,
+		h.ID(), C.int64_t(offset), C.int(whence)))
+	return int64(off), err
 }
 
 func (h Handle) Stat(path string) (Handle, error) {
@@ -267,13 +278,54 @@ func (h Handle) ImageOCISpecV1MarshalJSON() ([]byte, error) {
 	return result.Bytes(), nil
 }
 
-func DockerNew() (Handle, error) {
+func DockerMakeNewOptionList() Handle {
+	var result Handle
+	assertNoError(C.veinmind_DockerMakeNewOptionList(result.Ptr()))
+	return result
+}
+
+func DockerNew(opts Handle) (Handle, error) {
 	var result Handle
 	if err := handleError(C.veinmind_DockerNew(
-		result.Ptr())); err != nil {
+		result.Ptr(), opts.ID())); err != nil {
 		return 0, err
 	}
 	return result, nil
+}
+
+func DockerWithConfigPath(path string) Handle {
+	str := NewString(path)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_DockerWithConfigPath(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func DockerWithDataRootDir(path string) Handle {
+	str := NewString(path)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_DockerWithDataRootDir(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func DockerWithUniqueDesc(desc string) Handle {
+	str := NewString(desc)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_DockerWithUniqueDesc(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func (h Handle) DockerUniqueDesc() string {
+	var str Handle
+	assertNoError(C.veinmind_DockerUniqueDesc(
+		str.Ptr(), h.ID()))
+	defer str.Free()
+	return str.String()
 }
 
 func (h Handle) DockerImageOpenLayer(i int) (Handle, error) {
@@ -308,11 +360,52 @@ func (h Handle) DockerLayerID() string {
 	return result.String()
 }
 
-func ContainerdNew() (Handle, error) {
+func ContainerdMakeNewOptionList() Handle {
+	var result Handle
+	assertNoError(C.veinmind_ContainerdMakeNewOptionList(result.Ptr()))
+	return result
+}
+
+func ContainerdNew(opts Handle) (Handle, error) {
 	var result Handle
 	if err := handleError(C.veinmind_ContainerdNew(
-		result.Ptr())); err != nil {
+		result.Ptr(), opts.ID())); err != nil {
 		return 0, err
 	}
 	return result, nil
+}
+
+func ContainerdWithConfigPath(path string) Handle {
+	str := NewString(path)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_ContainerdWithConfigPath(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func ContainerdWithRootDir(path string) Handle {
+	str := NewString(path)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_ContainerdWithRootDir(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func ContainerdWithUniqueDesc(desc string) Handle {
+	str := NewString(desc)
+	defer str.Free()
+	var result Handle
+	assertNoError(C.veinmind_ContainerdWithUniqueDesc(
+		result.Ptr(), str.ID()))
+	return result
+}
+
+func (h Handle) ContainerdUniqueDesc() string {
+	var str Handle
+	assertNoError(C.veinmind_ContainerdUniqueDesc(
+		str.Ptr(), h.ID()))
+	defer str.Free()
+	return str.String()
 }

--- a/go/pkg/pflagext/pflagext.go
+++ b/go/pkg/pflagext/pflagext.go
@@ -1,0 +1,69 @@
+// Package pflagext is the extension of pflag which is part
+// of the cobra framework.
+package pflagext
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+type stringFuncValue func(string) error
+
+func (f stringFuncValue) Set(sval string) error {
+	return f(sval)
+}
+
+func (stringFuncValue) String() string {
+	return ""
+}
+
+func (stringFuncValue) Type() string {
+	return "string"
+}
+
+func StringVarFP(
+	fset *pflag.FlagSet, f func(string) error,
+	name, shorthand, usage string,
+) {
+	fset.VarP(stringFuncValue(f), name, shorthand, usage)
+}
+
+func StringVarF(
+	fset *pflag.FlagSet, f func(string) error,
+	name, usage string,
+) {
+	StringVarFP(fset, f, name, "", usage)
+}
+
+type intFuncValue func(int) error
+
+func (f intFuncValue) Set(sval string) error {
+	val, err := strconv.Atoi(sval)
+	if err != nil {
+		return err
+	}
+	return f(val)
+}
+
+func (intFuncValue) String() string {
+	return ""
+}
+
+func (intFuncValue) Type() string {
+	return "int"
+}
+
+func IntVarFP(
+	fset *pflag.FlagSet, f func(int) error,
+	name, shorthand string, usage string,
+) {
+	fset.VarP(intFuncValue(f), name, shorthand, usage)
+}
+
+func IntVarF(
+	fset *pflag.FlagSet, f func(int) error,
+	name string, usage string,
+) {
+	IntVarFP(fset, f, name, "", usage)
+}

--- a/python3/veinmind/binding.py
+++ b/python3/veinmind/binding.py
@@ -162,6 +162,13 @@ class Handle:
 				result.append(item.str())
 		return result
 
+	_append = lookup(b"veinmind_Append", b"VEINMIND_1.1")
+	def append(self, elem):
+		"When object is array, append the specified element to it."
+		if not isinstance(elem, Handle):
+			raise TypeError("elem must be Handle")
+		assert_no_error(Handle._append(self.val(), elem.val()))
+
 _bytes = lookup(b"veinmind_Bytes", b"VEINMIND_1.0")
 def new_bytes(value):
 	"Create a new bytes buffer to be used inside the binding."

--- a/python3/veinmind/command.py
+++ b/python3/veinmind/command.py
@@ -202,15 +202,35 @@ def mode(name=None, **kwargs):
 	return g
 
 @mode(name="docker")
+@decorators.option("--docker-config-path",
+	help='flag "--config-file" of dockerd command')
+@decorators.option("--docker-data-root",
+	help='flag "--data-root" of dockerd command')
+@decorators.option("--docker-unique-desc",
+	help='unique descriptor of the docker daemon')
 def _docker_mode(callback, **kwargs):
 	from . import docker
-	with docker.Docker() as d:
+	with docker.Docker(
+		config_path = kwargs.pop("docker_config_path", None),
+		data_root_dir = kwargs.pop("docker_data_root", None),
+		unique_desc = kwargs.pop("docker_unique_desc", None),
+	) as d:
 		callback(d)
 
 @mode(name="containerd")
+@decorators.option("--containerd-config",
+	help='flag "--config" of containerd command')
+@decorators.option("--containerd-root",
+	help='flag "--root" of containerd command')
+@decorators.option("--containerd-unique-desc",
+	help='unique descriptor of the containerd daemon')
 def _containerd_mode(callback, **kwargs):
 	from . import containerd
-	with containerd.Containerd() as c:
+	with containerd.Containerd(
+		config_path = kwargs.pop("containerd_config", None),
+		root_dir = kwargs.pop("containerd_root", None),
+		unique_desc = kwargs.pop("containerd_unique_desc", None),
+	) as c:
 		callback(c)
 
 class ModeCommand(PluginCommand):

--- a/python3/veinmind/containerd.py
+++ b/python3/veinmind/containerd.py
@@ -5,14 +5,66 @@ from . import image as image
 class Containerd(runtime.Runtime):
 	"Containerd refers to a parsed containerd application object."
 
-	# Initialize the docker object, assuming it is defaultly
-	# installed in the path '/var/lib/containerd'.
+	_with_config_path_fn = binding.lookup(
+		b"veinmind_ContainerdWithConfigPath", b"VEINMIND_1.1")
+	def _with_config_path(path):
+		if not isinstance(path, str):
+			raise TypeError("path must be str")
+		with binding.new_str(path) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Containerd._with_config_path_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	_with_root_dir_fn = binding.lookup(
+		b"veinmind_ContainerdWithRootDir", b"VEINMIND_1.1")
+	def _with_root_dir(path):
+		if not isinstance(path, str):
+			raise TypeError("path must be str")
+		with binding.new_str(path) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Containerd._with_root_dir_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	_with_unique_desc_fn = binding.lookup(
+		b"veinmind_ContainerdWithUniqueDesc", b"VEINMIND_1.1")
+	def _with_unique_desc(desc):
+		if not isinstance(desc, str):
+			raise TypeError("desc must be str")
+		with binding.new_str(desc) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Containerd._with_unique_desc_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	# Initialize the docker object, with specified arguments.
+	_make_new_option_list = binding.lookup(
+		b"veinmind_ContainerdMakeNewOptionList", b"VEINMIND_1.1")
 	_new = binding.lookup(
-		b"veinmind_ContainerdNew", b"VEINMIND_1.0")
-	def __init__(self):
-		handle = binding.Handle()
-		binding.handle_error(Containerd._new(handle.ptr()))
-		super(Containerd, self).__init__(handle=handle)
+		b"veinmind_ContainerdNew", b"VEINMIND_1.1")
+	def __init__(self, **kwargs):
+		hopts = binding.Handle()
+		binding.handle_error(
+			Containerd._make_new_option_list(hopts.ptr()))
+		with hopts as hopts:
+			config_path = kwargs.pop("config_path", None)
+			if config_path is not None:
+				with Containerd._with_config_path(config_path) as hopt:
+					hopts.append(hopt)
+			root_dir = kwargs.pop("root_dir", None)
+			if root_dir is not None:
+				with Containerd._with_root_dir(root_dir) as hopt:
+					hopts.append(hopt)
+			unique_desc = kwargs.pop("unique_desc", None)
+			if unique_desc is not None:
+				with Containerd._with_unique_desc(unique_desc) as hopt:
+					hopts.append(hopt)
+
+			handle = binding.Handle()
+			binding.handle_error(Containerd._new(
+				handle.ptr(), hopts.val()))
+			super(Containerd, self).__init__(handle=handle)
 
 	# Open a image by its ID and return the image object.
 	_open_image_by_id = binding.lookup(

--- a/python3/veinmind/docker.py
+++ b/python3/veinmind/docker.py
@@ -7,13 +7,65 @@ import ctypes as C
 class Docker(runtime.Runtime):
 	"Docker refers to a parsed docker application object."
 
-	# Initialize the docker object, assuming it is defaultly
-	# installed in the path '/var/lib/docker'.
-	_new = binding.lookup(b"veinmind_DockerNew", b"VEINMIND_1.0")
-	def __init__(self):
-		handle = binding.Handle()
-		binding.handle_error(Docker._new(handle.ptr()))
-		super(Docker, self).__init__(handle=handle)
+	_with_config_path_fn = binding.lookup(
+		b"veinmind_DockerWithConfigPath", b"VEINMIND_1.1")
+	def _with_config_path(path):
+		if not isinstance(path, str):
+			raise TypeError("path must be str")
+		with binding.new_str(path) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Docker._with_config_path_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	_with_data_root_dir_fn = binding.lookup(
+		b"veinmind_DockerWithDataRootDir", b"VEINMIND_1.1")
+	def _with_data_root_dir(path):
+		if not isinstance(path, str):
+			raise TypeError("path must be str")
+		with binding.new_str(path) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Docker._with_data_root_dir_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	_with_unique_desc_fn = binding.lookup(
+		b"veinmind_DockerWithUniqueDesc", b"VEINMIND_1.1")
+	def _with_unique_desc(desc):
+		if not isinstance(desc, str):
+			raise TypeError("desc must be str")
+		with binding.new_str(desc) as hstr:
+			hopt = binding.Handle()
+			binding.handle_error(Docker._with_unique_desc_fn(
+				hopt.ptr(), hstr.val()))
+			return hopt
+
+	# Initialize the docker object, with specified arguments.
+	_make_new_option_list = binding.lookup(
+		b"veinmind_DockerMakeNewOptionList", b"VEINMIND_1.1")
+	_new = binding.lookup(b"veinmind_DockerNew", b"VEINMIND_1.1")
+	def __init__(self, **kwargs):
+		hopts = binding.Handle()
+		binding.handle_error(
+			Docker._make_new_option_list(hopts.ptr()))
+		with hopts as hopts:
+			config_path = kwargs.pop("config_path", None)
+			if config_path is not None:
+				with Docker._with_config_path(config_path) as hopt:
+					hopts.append(hopt)
+			data_root_dir = kwargs.pop("data_root_dir", None)
+			if data_root_dir is not None:
+				with Docker._with_data_root_dir(data_root_dir) as hopt:
+					hopts.append(hopt)
+			unique_desc = kwargs.pop("unique_desc", None)
+			if unique_desc is not None:
+				with Docker._with_unique_desc(unique_desc) as hopt:
+					hopts.append(hopt)
+
+			handle = binding.Handle()
+			binding.handle_error(Docker._new(
+				handle.ptr(), hopts.val()))
+			super(Docker, self).__init__(handle=handle)
 
 	# Open a image by its ID and return the image object.
 	_open_image_by_id = binding.lookup(
@@ -26,6 +78,17 @@ class Docker(runtime.Runtime):
 			binding.handle_error(Docker._open_image_by_id(
 				handle.ptr(), self.__handle__().val(), hstr.val()))
 			return Image(handle)
+
+	_unique_desc = binding.lookup(
+		b"veinmind_DockerUniqueDesc", b"VEINMIND_1.1")
+	def unique_desc(self):
+		"Retrieve the correlated unique descriptor."
+
+		handle = binding.Handle()
+		binding.handle_error(Docker._unique_desc(
+			handle.ptr(), self.__handle__().val()))
+		with handle as handle:
+			return handle.str()
 
 class Layer(filesystem.FileSystem):
 	"Layer refers to a layer in docker image."

--- a/python3/veinmind/filesystem.py
+++ b/python3/veinmind/filesystem.py
@@ -250,6 +250,18 @@ class File(binding.Object, io.RawIOBase):
 	def writable(self):
 		return True
 
+	_seek = binding.lookup(
+		b"veinmind_Seek", b"VEINMIND_1.1")
+	def seek(self, offset, whence):
+		result = C.c_int64()
+		binding.handle_error(File._seek(C.pointer(result),
+			self.__handle__().val(),
+			C.c_int64(offset), C.c_int(whence)))
+		return result.value
+
+	def seekable(self):
+		return True
+
 class FileSystem(binding.Object):
 	def __init__(self, handle):
 		super(FileSystem, self).__init__(handle=handle)


### PR DESCRIPTION
1. 提升对非默认安装目录的 docker 和 containerd 运行时的兼容性。
2. 支持显式指定 docker 和 containerd 的配置文件和数据路径（API + 命令行）。
3. 支持获取 docker 和 containerd 的唯一标识符，以跨进程传递 API 对象（API + 命令行）。
4. API 文件对象支持 Seek 操作。
5. 提升依据名称匹配镜像 ID 的灵活性。