### PR TITLE
修复一些问题

### DIFF
--- a/go/plugin/discover.go
+++ b/go/plugin/discover.go
@@ -113,7 +113,7 @@ func (plug *Plugin) discover(ctx context.Context) error {
 		defer func() { _ = w.Close() }()
 		return plug.exec(errCtx, []string{"info"}, &os.ProcAttr{
 			Files: []*os.File{
-				nil, w, w,
+				nil, w,
 			},
 		})
 	})

--- a/go/plugin/service/server.go
+++ b/go/plugin/service/server.go
@@ -48,7 +48,9 @@ func newServiceFunc(service Service) serviceFunc {
 		jsonReply := make([]interface{}, numOut)
 		var callErr error
 		if lastError {
-			callErr = callReply[numOut-1].Interface().(error)
+			if errReply := callReply[numOut-1]; !errReply.IsNil() {
+				callErr = errReply.Interface().(error)
+			}
 			jsonReply = jsonReply[:numOut-1]
 		}
 		for i := 0; i < len(jsonReply); i++ {


### PR DESCRIPTION
1. 修复在 service 函数最后返回 error 并且 error 为空时，导致反射转换出错的问题。
2. 忽略插件 info 指令时的标准错误输出。